### PR TITLE
Derive impact on liquidity and flow test set

### DIFF
--- a/contracts/libraries/CurveRoll.sol
+++ b/contracts/libraries/CurveRoll.sol
@@ -73,7 +73,7 @@ library CurveRoll {
     }
 
     function deriveImpact (CurveMath.CurveState memory curve, uint256 flow,
-                           CurveMath.SwapAccum memory swap) private pure
+                           CurveMath.SwapAccum memory swap) internal pure
         returns (int256 counterFlow, uint160 nextPrice) {
         uint128 liq = curve.activeLiquidity();
         uint256 reserve = liq.reserveAtPrice(curve.priceRoot_, swap.cntx_.inBaseQty_);
@@ -84,7 +84,7 @@ library CurveRoll {
     
     function deriveFlowPrice (uint160 price, uint256 reserve,
                               uint256 flowMagn, CurveMath.SwapFrame memory cntx)
-        private pure returns (uint160) {
+        internal pure returns (uint160) {
         int256 flow = signFlow(flowMagn, cntx);
         uint256 nextReserve = flow > 0 ? reserve.add(uint256(flow)) :
             reserve.sub(uint256(-flow));

--- a/contracts/test/TestCurveMath.sol
+++ b/contracts/test/TestCurveMath.sol
@@ -158,11 +158,32 @@ contract TestCurveMath {
         (shiftGrowth, concGrowth) = (curve.accum_.ambientGrowth_,
                                      curve.accum_.concTokenGrowth_);
     }
+
+    function testDeriveFlowPrice (uint160 price, uint256 reserve, uint256 flow, 
+                                  bool isBuy, bool inBase)
+        public pure returns (uint160) {
+        CurveMath.SwapFrame memory cntx = CurveMath.SwapFrame(isBuy, inBase, 0, 0);
+
+        return CurveRoll.deriveFlowPrice(price, reserve, flow, cntx);
+        }
     
+    function testDeltaFlow (uint128 liq, uint128 startPrice, uint128 endPrice, bool inBase)
+        public pure returns (int256) {
+            return CurveMath.deltaFlow(liq, startPrice, endPrice, inBase);
+        }
+    
+    function testDeriveImpact (uint160 price, uint128 seed, uint256 growth, uint128 conc, uint256 flow, 
+                                  bool isBuy, bool inBase)
+        public pure returns (int256, uint160) {
+        CurveMath.CurveState memory curve = buildCurve(seed, growth, conc, price);
+        CurveMath.SwapAccum memory cntx = buildSwap(flow, isBuy, inBase);
+
+        return CurveRoll.deriveImpact(curve, flow, cntx);
+    }
+
     function buildSwap (uint256 flow, bool isBuy, bool inBase)
         private pure returns (CurveMath.SwapAccum memory) {
-        CurveMath.SwapFrame memory cntx = CurveMath.SwapFrame
-            (isBuy, inBase, 0, 0);
+        CurveMath.SwapFrame memory cntx = CurveMath.SwapFrame(isBuy, inBase, 0, 0);
         return CurveMath.SwapAccum(flow, 0, 0, 0, cntx);
     }
     


### PR DESCRIPTION
There appears to be potentially unacceptably large imprecision downstream of reserveAtPrice leading the protocol to overpay. See the test case in `TestCurveMath.ts:294-303`.

Case: 100 base units, 10000 quote units. Purchasing with a fixed payment of 150 base units. We should expect a rebalance to 250 base units and 4000 quote units, creating a new price of .0625 and an outward flow of -5999 quote units (offset by our rounding).

Independent Functions:
    derivePriceImpact: .0624999950000001
    deltaFlow: -6001

derivePriceImpact (downstream of reserveAtPrice):
    priceImpact: 0632598706795225
    flowChange: -6024