### PR TITLE
[Discard if unnecessary] Protocol fees to uint256

### DIFF
--- a/contracts/CrocSwapPool.sol
+++ b/contracts/CrocSwapPool.sol
@@ -431,16 +431,16 @@ contract CrocSwapPool is ICrocSwapPool,
 
     // @inheritdoc ICrocSwapV3PoolOwnerActions  
     function collectProtocol (address recipient)
-        protocolAuth external override returns (uint128, uint128) {
-        (uint128 baseFees, uint128 quoteFees) = disburseProtocol
+        protocolAuth external override returns (uint256, uint256) {
+        (uint256 baseFees, uint256 quoteFees) = disburseProtocol
             (recipient, tokenBase_, tokenQuote_);
         emit CollectProtocol(msg.sender, recipient, quoteFees, baseFees);
         return (quoteFees, baseFees);
     }
 
     // @inheritdoc ICrocSwapV3PoolState
-    function protocolFees() external view override returns (uint128, uint128) {
-        (uint128 baseFees, uint128 quoteFees) = protoFeeAccum();
+    function protocolFees() external view override returns (uint256, uint256) {
+        (uint256 baseFees, uint256 quoteFees) = protoFeeAccum();
         return (quoteFees, baseFees);
     }
     

--- a/contracts/interfaces/pool/ICrocSwapPoolEvents.sol
+++ b/contracts/interfaces/pool/ICrocSwapPoolEvents.sol
@@ -86,5 +86,5 @@ interface ICrocSwapPoolEvents {
     /// @param recipient The address that receives the collected protocol fees
     /// @param amount0 The amount of token0 protocol fees that is withdrawn
     /// @param amount0 The amount of token1 protocol fees that is withdrawn
-    event CollectProtocol(address indexed sender, address indexed recipient, uint128 amount0, uint128 amount1);
+    event CollectProtocol(address indexed sender, address indexed recipient, uint256 amount0, uint256 amount1);
 }

--- a/contracts/interfaces/pool/ICrocSwapPoolOwnerActions.sol
+++ b/contracts/interfaces/pool/ICrocSwapPoolOwnerActions.sol
@@ -14,5 +14,5 @@ interface ICrocSwapPoolOwnerActions {
     /// @return amount1 The protocol fee collected in token1
     function collectProtocol(
         address recipient
-    ) external returns (uint128 amount0, uint128 amount1);
+    ) external returns (uint256 amount0, uint256 amount1);
 }

--- a/contracts/interfaces/pool/ICrocSwapPoolState.sol
+++ b/contracts/interfaces/pool/ICrocSwapPoolState.sol
@@ -27,7 +27,7 @@ interface ICrocSwapPoolState {
 
     /// @notice The amounts of token0 and token1 that are owed to the protocol
     /// @dev Protocol fees will never exceed uint128 max in either token
-    function protocolFees() external view returns (uint128 token0, uint128 token1);
+    function protocolFees() external view returns (uint256 token0, uint256 token1);
 
     /// @notice The currently in range liquidity available to the pool
     /// @dev This value has no relationship to the total liquidity across all ticks

--- a/contracts/mixins/ProtocolAccount.sol
+++ b/contracts/mixins/ProtocolAccount.sol
@@ -11,17 +11,17 @@ pragma solidity >0.7.1;
  * @dev Unlike liquidity fees, protocol fees are accumulated as resting tokens 
  *      instead of ambient liquidity. */
 contract ProtocolAccount {
-    
-    uint128 private protoFeesBase_;
-    uint128 private protoFeesQuote_;
+
+    uint256 private protoFeesBase_;
+    uint256 private protoFeesQuote_;
 
     /* @notice Called at the completion of a swap event, incrementing any protocol
      *         fees accumulated in the swap. */
     function accumProtocolFees (CurveMath.SwapAccum memory accum) internal {
         if (accum.cntx_.inBaseQty_) {
-            protoFeesBase_ += uint128(accum.paidProto_);
+            protoFeesBase_ += accum.paidProto_;
         } else {
-            protoFeesQuote_ += uint128(accum.paidProto_);
+            protoFeesQuote_ += accum.paidProto_;
         }
     }
 
@@ -36,7 +36,7 @@ contract ProtocolAccount {
      *                    before the disburse call. */
     function disburseProtocol (address recipient,
                                address tokenQuote, address tokenBase)
-        internal returns (uint128 quoteFees, uint128 baseFees) {
+        internal returns (uint256 quoteFees, uint256 baseFees) {
         baseFees = protoFeesBase_;
         quoteFees = protoFeesQuote_;
         protoFeesBase_ = 0;
@@ -46,7 +46,7 @@ contract ProtocolAccount {
     }
 
     
-    function transferFees (uint128 amount, address token,
+    function transferFees (uint256 amount, address token,
                            address recipient) private {
         if (amount > 0) {
             TransferHelper.safeTransfer(token, recipient, amount);
@@ -55,7 +55,7 @@ contract ProtocolAccount {
 
     /* @notice Retrieves the balance of the protocol unclaimed fees currently resting
      *         in the pool. */
-    function protoFeeAccum() internal view returns (uint128, uint128) {
+    function protoFeeAccum() internal view returns (uint256, uint256) {
         return (protoFeesQuote_, protoFeesBase_);
     }
 }

--- a/contracts/test/TestProtocolAcct.sol
+++ b/contracts/test/TestProtocolAcct.sol
@@ -27,7 +27,7 @@ contract TestProtocolAccount is ProtocolAccount {
         disburseProtocol(client_, tokenBase_, tokenQuote_);
     }
 
-    function getAccum() public view returns (uint128, uint128) {
+    function getAccum() public view returns (uint256, uint256) {
         return protoFeeAccum();
     }
 }


### PR DESCRIPTION
Protocol fees appear to be overflowing in unit tests after adding safe casts in #12. Option to migrate them to uint256 from uint128.