### PR TITLE
add SD error to error list

### DIFF
--- a/etc/errors.json
+++ b/etc/errors.json
@@ -25,6 +25,7 @@
     "R": "Price outside tick range",
     "RB": "Swap Curve Boundary Crash",
     "S": "Mezzanine spill broken",
+    "SD": "Swap price exceeds directional limit",
     "SL": "Swap output exceeds slippage",
     "ST": "Terminus spill broken",
     "T": "Price below max tick",


### PR DESCRIPTION
# Summary
This PR adds the `SD` error to the `error.json` list in the `misc` directory
